### PR TITLE
Added support for .nu TLD

### DIFF
--- a/check_domain
+++ b/check_domain
@@ -155,7 +155,10 @@ case "$domain" in
 *.net)
 	expiration=$(echo "$out" | awk -F: '/   Expiration Date:/{print substr($0, length($1) + 3, 11)}')
 	;;
-#*.nu)
+*.nu)
+	expiration=$(echo "$out" | grep expires | awk '{print $2}')
+	;;
+#*.nu) # I'll leave this in just in case /Jack-Benny
 # This doesn't work, yet. Need to convert 3-letter month into number. -Ryan, Aug 21, 2013
 #	expmonth=$(echo "$out" | awk -F '/Record expires on/{print substr($4, length($1) + 2)}'}
 #	echo $expmonth


### PR DESCRIPTION
I've added support for .nu TLD. They seem to have change their whois data information, it's now in the simple format YYYY-MM-DD. I've tried it with both Swedish, Russian and US registered .nu domains and it seems to be working. Try it out just in case.
